### PR TITLE
Return empty ItemStacks instead of null ones

### DIFF
--- a/src/main/java/ferro2000/immersivetech/common/blocks/metal/tileentities/TileEntityAlternator.java
+++ b/src/main/java/ferro2000/immersivetech/common/blocks/metal/tileentities/TileEntityAlternator.java
@@ -153,12 +153,12 @@ public class TileEntityAlternator extends TileEntityMultiblockPart<TileEntityAlt
 	@Override
 	public ItemStack getOriginalBlock() {
 		if(pos<0)
-			return null;
-		ItemStack s = null;
+			return ItemStack.EMPTY;
+		ItemStack s = ItemStack.EMPTY;
 		try{
 			s = MultiblockAlternator.instance.getStructureManual()[pos/12][pos%12/3][pos%3];
 		}catch(Exception e){e.printStackTrace();}
-		return s!=null?s.copy():null;
+		return s.copy();
 	}
 
 	@Override

--- a/src/main/java/ferro2000/immersivetech/common/blocks/metal/tileentities/TileEntitySolarReflector.java
+++ b/src/main/java/ferro2000/immersivetech/common/blocks/metal/tileentities/TileEntitySolarReflector.java
@@ -82,14 +82,14 @@ public class TileEntitySolarReflector extends TileEntityMultiblockPart<TileEntit
 	@Override
 	public ItemStack getOriginalBlock() {
 		if (pos < 0)
-			return null;
-		ItemStack s = null;
+			return ItemStack.EMPTY;
+		ItemStack s = ItemStack.EMPTY;
 		try {
 			s = MultiblockSolarReflector.instance.getStructureManual()[pos / 3][0][pos % 3];
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-		return s != null ? s.copy() : null;
+		return s.copy();
 	}
 
 	@Override

--- a/src/main/java/ferro2000/immersivetech/common/blocks/stone/tileentities/TileEntityCokeOvenAdvanced.java
+++ b/src/main/java/ferro2000/immersivetech/common/blocks/stone/tileentities/TileEntityCokeOvenAdvanced.java
@@ -504,12 +504,12 @@ public class TileEntityCokeOvenAdvanced extends TileEntityMultiblockPart<TileEnt
 	@Override
 	public ItemStack getOriginalBlock() {
 		if(pos<0)
-			return null;
-		ItemStack s = null;
+			return ItemStack.EMPTY;
+		ItemStack s = ItemStack.EMPTY;
 		try{
 			s = MultiblockCokeOvenAdvanced.instance.getStructureManual()[pos/9][pos%9/3][pos%3];
 		}catch(Exception e){e.printStackTrace();}
-		return s!=null?s.copy():null;
+		return s.copy();
 	}
 
 	IItemHandler inputHandler = new IEInventoryHandler(1, this, 0, new boolean[] {true}, new boolean[] {false});


### PR DESCRIPTION
This is how IE does it now too, to avoid exactly this crash:
https://github.com/BluSunrize/ImmersiveEngineering/blob/f03bf5b43ff7c8f03cfb7f06a5727ccfdd2cb855/src/main/java/blusunrize/immersiveengineering/common/blocks/metal/TileEntityLightningrod.java#L191-L201

Fixes McJtyMods/TheOneProbe#251.